### PR TITLE
Fix accessory rendering to make drawing behind hair work

### DIFF
--- a/FashionSense/Framework/Patches/Renderer/FarmerRendererPatch.cs
+++ b/FashionSense/Framework/Patches/Renderer/FarmerRendererPatch.cs
@@ -1247,12 +1247,8 @@ namespace FashionSense.Framework.Patches.Renderer
                 accessoryColor = Utility.GetPrismaticColor(speedMultiplier: accessoryModel.PrismaticAnimationSpeedMultiplier);
             }
 
-            // Correct how the accessory is drawn according to facingDirection and AccessoryModel.DrawBehindHair
-            var layerFix = facingDirection == 0 ? (accessoryModel.DrawBeforeHair ? 3.9E-05f : 0) : (accessoryModel.DrawBeforeHair ? -0.1E-05f : 2.9E-05f);
-            if (isDrawingForUI)
-            {
-                layerFix = facingDirection == 0 ? (accessoryModel.DrawBeforeHair ? 3.9E-05f : 2E-05f) : (accessoryModel.DrawBeforeHair ? -0.1E-05f : 3.9E-05f);
-            }
+            // Correct how the accessory is drawn according to AccessoryModel.DrawBehindHair
+            var layerFix = (accessoryModel.DrawBeforeHair ? 3.9E-05f : 1.0E-05f);
 
             if (accessoryModel.DrawAfterSleeves)
             {


### PR DESCRIPTION
First of all, FashionSense is great! I tried to use accessory as a secondary hair layer to be able to recolor the sides of a mohawk differently. This didn't work so I adjusted the layerFix variable. The result seems to work well for that use case and the code is even simpler than before. Test content pack attached.

[BuzzcutAsAccessory.zip](https://github.com/Floogen/FashionSense/files/8500351/BuzzcutAsAccessory.zip)
