### PR TITLE
Improved linux compatibility

### DIFF
--- a/FashionSense/FashionSense.cs
+++ b/FashionSense/FashionSense.cs
@@ -513,19 +513,19 @@ namespace FashionSense
             }
         }
 
-        private static DirectoryInfo GetContentPackDirectory(IContentPack contentPack, string name)
+        private static DirectoryInfo GetContentPackDirectory(IContentPack contentPack, string targetDirectoryName)
         {
             var contentPackDirectory = new DirectoryInfo(contentPack.DirectoryPath);
 
             foreach (var directory in contentPackDirectory.GetDirectories())
             {
-                if (directory.Name.ToLower() == name.ToLower())
+                if (directory.Name.Equals(targetDirectoryName, StringComparison.OrdinalIgnoreCase))
                 {
                     return directory;
                 }
             }
 
-            return new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, name));
+            return new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, targetDirectoryName));
         }
 
         private void AddHairContentPacks(IContentPack contentPack)
@@ -539,7 +539,7 @@ namespace FashionSense
                     return;
                 }
 
-                var hairFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
+                var hairFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy(d => d.Name);
                 if (hairFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Hairs for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -655,7 +655,7 @@ namespace FashionSense
                     return;
                 }
 
-                var accessoryFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
+                var accessoryFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy(d => d.Name);
                 if (accessoryFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Accessories for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -771,7 +771,7 @@ namespace FashionSense
                     return;
                 }
 
-                var hatFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
+                var hatFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy(d => d.Name);
                 if (hatFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Hats for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -887,7 +887,7 @@ namespace FashionSense
                     return;
                 }
 
-                var shirtFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
+                var shirtFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy(d => d.Name);
                 if (shirtFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Shirts for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -1003,7 +1003,7 @@ namespace FashionSense
                     return;
                 }
 
-                var pantsFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
+                var pantsFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy(d => d.Name);
                 if (pantsFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Pants for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -1119,7 +1119,7 @@ namespace FashionSense
                     return;
                 }
 
-                var sleevesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
+                var sleevesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy(d => d.Name);
                 if (sleevesFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Sleeves for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -1235,7 +1235,7 @@ namespace FashionSense
                     return;
                 }
 
-                var shoesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
+                var shoesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy(d => d.Name);
                 if (shoesFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Shoes for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -1351,7 +1351,7 @@ namespace FashionSense
                     return;
                 }
 
-                var bodiesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
+                var bodiesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy(d => d.Name);
                 if (bodiesFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Bodies for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);

--- a/FashionSense/FashionSense.cs
+++ b/FashionSense/FashionSense.cs
@@ -513,11 +513,26 @@ namespace FashionSense
             }
         }
 
+        private static DirectoryInfo GetContentPackDirectory(IContentPack contentPack, string name)
+        {
+            var contentPackDirectory = new DirectoryInfo(contentPack.DirectoryPath);
+
+            foreach (var directory in contentPackDirectory.GetDirectories())
+            {
+                if (directory.Name.ToLower() == name.ToLower())
+                {
+                    return directory;
+                }
+            }
+
+            return new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, name));
+        }
+
         private void AddHairContentPacks(IContentPack contentPack)
         {
             try
             {
-                var directoryPath = new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, "Hairs"));
+                var directoryPath = GetContentPackDirectory(contentPack, "Hairs");
                 if (!directoryPath.Exists)
                 {
                     Monitor.Log($"No Hairs folder found for the content pack {contentPack.Manifest.Name}", LogLevel.Trace);
@@ -633,7 +648,7 @@ namespace FashionSense
         {
             try
             {
-                var directoryPath = new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, "Accessories"));
+                var directoryPath = GetContentPackDirectory(contentPack, "Accessories");
                 if (!directoryPath.Exists)
                 {
                     Monitor.Log($"No Accessories folder found for the content pack {contentPack.Manifest.Name}", LogLevel.Trace);
@@ -749,7 +764,7 @@ namespace FashionSense
         {
             try
             {
-                var directoryPath = new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, "Hats"));
+                var directoryPath = GetContentPackDirectory(contentPack, "Hats");
                 if (!directoryPath.Exists)
                 {
                     Monitor.Log($"No Hats folder found for the content pack {contentPack.Manifest.Name}", LogLevel.Trace);
@@ -865,7 +880,7 @@ namespace FashionSense
         {
             try
             {
-                var directoryPath = new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, "Shirts"));
+                var directoryPath = GetContentPackDirectory(contentPack, "Shirts");
                 if (!directoryPath.Exists)
                 {
                     Monitor.Log($"No Shirts folder found for the content pack {contentPack.Manifest.Name}", LogLevel.Trace);
@@ -981,7 +996,7 @@ namespace FashionSense
         {
             try
             {
-                var directoryPath = new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, "Pants"));
+                var directoryPath = GetContentPackDirectory(contentPack, "Pants");
                 if (!directoryPath.Exists)
                 {
                     Monitor.Log($"No Pants folder found for the content pack {contentPack.Manifest.Name}", LogLevel.Trace);
@@ -1097,7 +1112,7 @@ namespace FashionSense
         {
             try
             {
-                var directoryPath = new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, "Sleeves"));
+                var directoryPath = GetContentPackDirectory(contentPack, "Sleeves");
                 if (!directoryPath.Exists)
                 {
                     Monitor.Log($"No Sleeves folder found for the content pack {contentPack.Manifest.Name}", LogLevel.Trace);
@@ -1213,7 +1228,7 @@ namespace FashionSense
         {
             try
             {
-                var directoryPath = new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, "Shoes"));
+                var directoryPath = GetContentPackDirectory(contentPack, "Shoes");
                 if (!directoryPath.Exists)
                 {
                     Monitor.Log($"No Shoes folder found for the content pack {contentPack.Manifest.Name}", LogLevel.Trace);
@@ -1329,7 +1344,7 @@ namespace FashionSense
         {
             try
             {
-                var directoryPath = new DirectoryInfo(Path.Combine(contentPack.DirectoryPath, "Bodies"));
+                var directoryPath = GetContentPackDirectory(contentPack, "Bodies");
                 if (!directoryPath.Exists)
                 {
                     Monitor.Log($"No Bodies folder found for the content pack {contentPack.Manifest.Name}", LogLevel.Trace);

--- a/FashionSense/FashionSense.cs
+++ b/FashionSense/FashionSense.cs
@@ -539,7 +539,7 @@ namespace FashionSense
                     return;
                 }
 
-                var hairFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories);
+                var hairFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
                 if (hairFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Hairs for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -655,7 +655,7 @@ namespace FashionSense
                     return;
                 }
 
-                var accessoryFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories);
+                var accessoryFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
                 if (accessoryFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Accessories for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -771,7 +771,7 @@ namespace FashionSense
                     return;
                 }
 
-                var hatFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories);
+                var hatFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
                 if (hatFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Hats for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -887,7 +887,7 @@ namespace FashionSense
                     return;
                 }
 
-                var shirtFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories);
+                var shirtFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
                 if (shirtFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Shirts for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -1003,7 +1003,7 @@ namespace FashionSense
                     return;
                 }
 
-                var pantsFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories);
+                var pantsFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
                 if (pantsFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Pants for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -1119,7 +1119,7 @@ namespace FashionSense
                     return;
                 }
 
-                var sleevesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories);
+                var sleevesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
                 if (sleevesFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Sleeves for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -1235,7 +1235,7 @@ namespace FashionSense
                     return;
                 }
 
-                var shoesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories);
+                var shoesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
                 if (shoesFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Shoes for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);
@@ -1351,7 +1351,7 @@ namespace FashionSense
                     return;
                 }
 
-                var bodiesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories);
+                var bodiesFolders = directoryPath.GetDirectories("*", SearchOption.AllDirectories).OrderBy((k) => k.Name);
                 if (bodiesFolders.Count() == 0)
                 {
                     Monitor.Log($"No sub-folders found under Bodies for the content pack {contentPack.Manifest.Name}", LogLevel.Warn);


### PR DESCRIPTION
### Improved Linux compatibility

Heyo, love the mod! I've been unable to live without it since I first found it don't know how long ago.

I recently transitioned from playing SDV on Windows to Linux and noticed a couple of bugs/inconveniences in FashionSense:

- The filesystem on Linux is case-sensitive, meaning `Hairs` and `hairs` are not the same folder. This leads to some content packs not loading their sprites; e.g. [Churpy's Vivid Hairstyles](https://www.nexusmods.com/stardewvalley/mods/19125) which named its Hairs folder `hairs`. The content pack would load but it wouldn't provide anything.

  - I fixed this by defining a new method, `GetContentPackDirectory`, to wrap around all the calls to `new DirectoryEntry` and check for the existence of the folder in a case-insensitive manner.

- C#'s `GetDirectories()` method does not guarantee any particular order for the returned list. This is fine on Windows where the filesystem will sort files alphabetically anyway, but on Linux this ends up with the sprites being in semi-random order, which is mildly inconvenient when browsing around.

  - I fixed this by using an ordered iterator to walk through the list (obtained with `.OrderBy((k) => k.Name)`).

If you want any changes to the PR, do let me know.