### PR TITLE
Cashed the SkinColors and Color

### DIFF
--- a/FashionSense/Framework/Patches/Renderer/DrawPatch.cs
+++ b/FashionSense/Framework/Patches/Renderer/DrawPatch.cs
@@ -26,6 +26,31 @@ namespace FashionSense.Framework.Patches.Renderer
 {
     internal class DrawPatch : PatchTemplate
     {
+        // PERF: cache skin color lookup texture + raw data so we don't Load/GetData every draw call.
+        private static readonly object _skinColorsLock = new();
+        private static Texture2D _skinColorsTexture;
+        private static Color[] _skinColorsData;
+        private static int _skinColorsWidth;
+        private static int _skinColorsHeight;
+
+        private static Texture2D GetSkinColorsTexture(LocalizedContentManager farmerTextureManager)
+        {
+            // LocalizedContentManager.Load caches internally, but calling it thousands of times per second still adds overhead,
+            // and GetData is extremely expensive. Cache both the texture and its data.
+            lock (_skinColorsLock)
+            {
+                _skinColorsTexture ??= farmerTextureManager.Load<Texture2D>(@"Characters\Farmer\skinColors");
+                if (_skinColorsData is null || _skinColorsWidth != _skinColorsTexture.Width || _skinColorsHeight != _skinColorsTexture.Height)
+                {
+                    _skinColorsWidth = _skinColorsTexture.Width;
+                    _skinColorsHeight = _skinColorsTexture.Height;
+                    _skinColorsData = new Color[_skinColorsWidth * _skinColorsHeight];
+                    _skinColorsTexture.GetData(_skinColorsData);
+                }
+                return _skinColorsTexture;
+            }
+        }
+
         internal static float? lastCustomLayerDepth;
         private readonly Type _entity = typeof(FarmerRenderer);
 
@@ -460,8 +485,8 @@ namespace FashionSense.Framework.Patches.Renderer
 
         internal static SkinToneModel GetSkinTone(LocalizedContentManager farmerTextureManager, Texture2D baseTexture, Color[] pixels, NetInt skin, bool sickFrame, Farmer who)
         {
-            Texture2D skinColors = farmerTextureManager.Load<Texture2D>("Characters\\Farmer\\skinColors");
-            Color[] skinColorsData = new Color[skinColors.Width * skinColors.Height];
+            Texture2D skinColors = GetSkinColorsTexture(farmerTextureManager);
+            Color[] skinColorsData = _skinColorsData;
             int skin_index = skin.Value;
 
             if (skin_index < 0)
@@ -473,8 +498,7 @@ namespace FashionSense.Framework.Patches.Renderer
                 skin_index = 0;
             }
 
-            skinColors.GetData(skinColorsData);
-            Color darkest = skinColorsData[skin_index * 3 % (skinColors.Height * 3)];
+                        Color darkest = skinColorsData[skin_index * 3 % (skinColors.Height * 3)];
             Color medium = skinColorsData[skin_index * 3 % (skinColors.Height * 3) + 1];
             Color lightest = skinColorsData[skin_index * 3 % (skinColors.Height * 3) + 2];
 
@@ -489,6 +513,7 @@ namespace FashionSense.Framework.Patches.Renderer
                 if (pixels is null)
                 {
                     pixels = new Color[baseTexture.Width * baseTexture.Height];
+                    baseTexture.GetData(pixels);
                 }
                 darkest = pixels[260 + baseTexture.Width];
                 medium = pixels[261 + baseTexture.Width];

--- a/FashionSense/Framework/Patches/Renderer/DrawPatch.cs
+++ b/FashionSense/Framework/Patches/Renderer/DrawPatch.cs
@@ -26,32 +26,15 @@ namespace FashionSense.Framework.Patches.Renderer
 {
     internal class DrawPatch : PatchTemplate
     {
-        // PERF: cache skin color lookup texture + raw data so we don't Load/GetData every draw call.
+        // Performance related to caching skin texture and related data
         private static readonly object _skinColorsLock = new();
         private static Texture2D _skinColorsTexture;
         private static Color[] _skinColorsData;
         private static int _skinColorsWidth;
         private static int _skinColorsHeight;
 
-        private static Texture2D GetSkinColorsTexture(LocalizedContentManager farmerTextureManager)
-        {
-            // LocalizedContentManager.Load caches internally, but calling it thousands of times per second still adds overhead,
-            // and GetData is extremely expensive. Cache both the texture and its data.
-            lock (_skinColorsLock)
-            {
-                _skinColorsTexture ??= farmerTextureManager.Load<Texture2D>(@"Characters\Farmer\skinColors");
-                if (_skinColorsData is null || _skinColorsWidth != _skinColorsTexture.Width || _skinColorsHeight != _skinColorsTexture.Height)
-                {
-                    _skinColorsWidth = _skinColorsTexture.Width;
-                    _skinColorsHeight = _skinColorsTexture.Height;
-                    _skinColorsData = new Color[_skinColorsWidth * _skinColorsHeight];
-                    _skinColorsTexture.GetData(_skinColorsData);
-                }
-                return _skinColorsTexture;
-            }
-        }
-
         internal static float? lastCustomLayerDepth;
+
         private readonly Type _entity = typeof(FarmerRenderer);
 
         internal DrawPatch(IMonitor modMonitor, IModHelper modHelper) : base(modMonitor, modHelper)
@@ -498,7 +481,7 @@ namespace FashionSense.Framework.Patches.Renderer
                 skin_index = 0;
             }
 
-                        Color darkest = skinColorsData[skin_index * 3 % (skinColors.Height * 3)];
+            Color darkest = skinColorsData[skin_index * 3 % (skinColors.Height * 3)];
             Color medium = skinColorsData[skin_index * 3 % (skinColors.Height * 3) + 1];
             Color lightest = skinColorsData[skin_index * 3 % (skinColors.Height * 3) + 2];
 
@@ -540,6 +523,24 @@ namespace FashionSense.Framework.Patches.Renderer
             }
 
             return new SkinToneModel(lightest, medium, darkest);
+        }
+
+        private static Texture2D GetSkinColorsTexture(LocalizedContentManager farmerTextureManager)
+        {
+            // LocalizedContentManager.Load caches internally, but calling it thousands of times per second still adds overhead and GetData is extremely expensive
+            // Cache both the texture and its data
+            lock (_skinColorsLock)
+            {
+                _skinColorsTexture ??= farmerTextureManager.Load<Texture2D>(@"Characters\Farmer\skinColors");
+                if (_skinColorsData is null || _skinColorsWidth != _skinColorsTexture.Width || _skinColorsHeight != _skinColorsTexture.Height)
+                {
+                    _skinColorsWidth = _skinColorsTexture.Width;
+                    _skinColorsHeight = _skinColorsTexture.Height;
+                    _skinColorsData = new Color[_skinColorsWidth * _skinColorsHeight];
+                    _skinColorsTexture.GetData(_skinColorsData);
+                }
+                return _skinColorsTexture;
+            }
         }
 
         internal static void ExecuteRecolorActionsReversePatch(FarmerRenderer __instance, Farmer who)


### PR DESCRIPTION
Was getting a massive slow down when using a pack and found this was the cause. Was basically spamming itself.

For reference was getting a fps drop of around 30 before and now it's a smooth 60.
There are more areas that need a little something but this was the main and most impactful one, from my testing.

Would you like a video showing a before and after? It won't show up that well through recording, but having an fps overlay enabled could help.