### PR TITLE
Fixed bug where mods cannot use API to change Fashion Sense bodies

### DIFF
--- a/FashionSense/Framework/Interfaces/API/Api.cs
+++ b/FashionSense/Framework/Interfaces/API/Api.cs
@@ -267,6 +267,9 @@ namespace FashionSense.Framework.Interfaces.API
                 case IApi.Type.Shoes:
                     modDataKey = ModDataKeys.CUSTOM_SHOES_ID;
                     break;
+                case IApi.Type.Player:
+                    modDataKey = ModDataKeys.CUSTOM_BODY_ID;
+                    break;
             }
 
             return modDataKey;

--- a/FashionSense/Framework/Interfaces/API/Api.cs
+++ b/FashionSense/Framework/Interfaces/API/Api.cs
@@ -30,7 +30,8 @@ namespace FashionSense.Framework.Interfaces.API
             Pants,
             Sleeves,
             Shoes,
-            Player
+            Player,
+            Body
         }
 
         public record RawTextureData(int Width, int Height, Color[] Data) : IRawTextureData;
@@ -268,6 +269,7 @@ namespace FashionSense.Framework.Interfaces.API
                     modDataKey = ModDataKeys.CUSTOM_SHOES_ID;
                     break;
                 case IApi.Type.Player:
+                case IApi.Type.Body:
                     modDataKey = ModDataKeys.CUSTOM_BODY_ID;
                     break;
             }


### PR DESCRIPTION
Here is my suggested fix for issue https://github.com/Floogen/FashionSense/issues/57. GetAppearanceModDataKey() can now return the ModDataKeys.CUSTOM_BODY_ID key for the IApi.Type.Player type, which should fix the bug where mods couldn't use the API to change Fashion Sense bodies. 

Also, I added an IApi.Type.Body type as an alias to the Player type, because it's more consistent and easier for other devs using the API to understand. If you'd prefer to keep just the Player type, Floogen, I completely understand. I'm not great with Git but hopefully separating the two commits makes that easier for you to do. 